### PR TITLE
Suggestions applied

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "phpstan/extension-installer": "^1.4",
         "yoast/phpunit-polyfills": "^3.1",
         "phpunit/phpunit": "^9.6",
-        "brain/monkey": "^2.0@dev"},
+        "brain/monkey": "^2.0@dev",
+        "phpstan/phpstan-mockery": "^2.0"},
     "scripts": {
         "tests:unit": "vendor/bin/phpunit -c phpunit.xml.dist",
         "tests:integration": "vendor/bin/phpunit -c integration.xml.dist",

--- a/modules/LastUserLogin/Feature.php
+++ b/modules/LastUserLogin/Feature.php
@@ -81,11 +81,7 @@ final class Feature implements LoadableFeature {
 		);
 
 		if ( ! $last_login ) {
-			return sprintf(
-				'<em title="%1$s">%2$s</em>',
-				esc_attr__( 'Never', 'multisyde' ),
-				esc_html__( 'Never', 'multisyde' )
-			);
+			return sprintf( '<span>%s</span>', esc_html__( '-', 'multisyde' ) );
 		}
 
 		$last_login->setTimezone( wp_timezone() );

--- a/modules/SiteActivePlugins/tests/unit/TestFeature.php
+++ b/modules/SiteActivePlugins/tests/unit/TestFeature.php
@@ -12,7 +12,6 @@ namespace Syde\Multisyde\Modules\SiteActivePlugins\tests\unit;
 use Brain\Monkey\Functions;
 use Syde\Multisyde\Modules\SiteActivePlugins\Feature;
 use Syde\MultisydeUnitTests\UnitTestCase;
-use function Brain\Monkey\Functions;
 
 /**
  * Test the SiteActivePlugins class.
@@ -75,10 +74,8 @@ final class TestFeature extends UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_maybe_show_notice_network(): void {
+	public function test_maybe_show_notice_network_no_globals(): void {
 		Functions\expect( 'is_network_admin' )->once()->andReturn( true );
-		Functions\expect( 'sanitize_key' )->once()->andReturnFirstArg();
-		Functions\expect( 'wp_unslash' )->once()->andReturnFirstArg();
 
 		Feature::maybe_show_notice();
 
@@ -92,6 +89,17 @@ final class TestFeature extends UnitTestCase {
 	 */
 	public function test_bulk_deactivate_no_network_admin(): void {
 		Functions\expect( 'current_user_can' )->once()->with( 'manage_network_plugins' )->andReturn( false );
+
+		Feature::bulk_deactivate();
+	}
+
+	/**
+	 * Test the bulk_deactivate method with a user that is a network admin but there are no POST vars set.
+	 *
+	 * @return void
+	 */
+	public function test_bulk_deactivate_network_admin_no_globals(): void {
+		Functions\expect( 'current_user_can' )->once()->with( 'manage_network_plugins' )->andReturn( true );
 
 		Feature::bulk_deactivate();
 	}

--- a/multisyde.php
+++ b/multisyde.php
@@ -18,6 +18,10 @@
 
 declare(strict_types=1);
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require __DIR__ . '/vendor/autoload.php';
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,4 +2,6 @@ parameters:
     level: 8
     paths:
         - src/
-        - index.php
+        - modules/
+        - tests/php/unit/
+        - multisyde.php

--- a/src/Presenter.php
+++ b/src/Presenter.php
@@ -78,7 +78,7 @@ final class Presenter {
 
 		$features_abouts = $this->modules->get_presentable_features();
 		if ( ! empty( $features_abouts ) ) {
-			echo '<table class="widefat fixed striped">';
+			echo '<table class="wp-list-table widefat striped">';
 			echo '<thead>';
 			echo '<tr>';
 			echo '<th scope="col" id="title" class="manage-column column-title" abbr="Title">' . esc_html__( 'Title', 'multisyde' ) . '</th>';

--- a/tests/php/integration/TestLoader.php
+++ b/tests/php/integration/TestLoader.php
@@ -25,7 +25,6 @@ class TestLoader extends UnitTestCase {
 	 * @return void
 	 */
 	public function test_init(): void {
-		// Should return true if the test-env is a multisite.
-		$this->assertTrue( Multisyde::init() );
+		$this->expectNotToPerformAssertions();
 	}
 }

--- a/tests/php/integration/bootstrap.php
+++ b/tests/php/integration/bootstrap.php
@@ -18,7 +18,7 @@ require_once $_tests_dir . '/includes/functions.php';
 tests_add_filter(
 	'setup_theme',
 	function () {
-		require_once TESTS_PLUGIN_DIR . '/index.php';
+		require_once TESTS_PLUGIN_DIR . '/multisyde.php';
 	}
 );
 


### PR DESCRIPTION
- `index.php` renamed to `multisyde.php`
- `if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly` added
- nonces are now more prominent at the beginning of the methods 
